### PR TITLE
Add custom Component class with deferSetState to prevent `An update was suspended for longer than the timeout, but no fallback UI was provided.`

### DIFF
--- a/src/Component.js
+++ b/src/Component.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default class Component extends React.Component {
+    deferSetState(state, sideEffects) {
+        ReactDOM.unstable_deferredUpdates(() => this.setState(state, sideEffects));
+    }
+}

--- a/src/MiniRouter.js
+++ b/src/MiniRouter.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { createBrowserHistory } from 'history';
 import { matchPath } from './matchPath';
+
+import Component from './Component';
+
 const RouterContext = React.createContext(null);
 
 export const withRouter = Comp => props => (
@@ -9,7 +12,7 @@ export const withRouter = Comp => props => (
   </RouterContext.Consumer>
 );
 
-export class Router extends React.Component {
+export class Router extends Component {
   history = createBrowserHistory();
 
   state = {
@@ -18,7 +21,7 @@ export class Router extends React.Component {
 
   componentDidMount() {
     this.history.listen(() => {
-      this.setState({
+      this.deferSetState({
         location: this.history.location,
       });
     });


### PR DESCRIPTION
When running the example everything goes fine, but, sometimes you can see the following error when trying to transition between routes: `An update was suspended for longer than the timeout, but no fallback UI was provided.`

To prevent this issue, you have to defer the state update for `location` in your `Router component`. In his talk, Dan Abramov uses a method called deferSetState, it isn't implemented yet, but you can do it on your own if you extend `React.Component` and use `ReactDOM.unstable_deferredUpdates` in this way: 

```JSX
import React from 'react';
import ReactDOM from 'react-dom';

export default class Component extends React.Component {
    deferSetState(state, sideEffects) {
        ReactDOM.unstable_deferredUpdates(() => this.setState(state, sideEffects));
    }
}
```

Well, that's all. 